### PR TITLE
Update lxc.spec: Add seccomp as build dependency

### DIFF
--- a/lxc.spec
+++ b/lxc.spec
@@ -25,6 +25,7 @@ Source100:	lxc.rpmlintrc
 BuildRequires:	docbook-utils
 BuildRequires:	kernel-release-headers
 BuildRequires:	cap-devel
+BuildRequires:  seccomp-devel
 BuildRequires:	pkgconfig(libsystemd)
 BuildRequires:	pkgconfig(dbus-1)
 BuildRequires:	docbook-dtd30-sgml


### PR DESCRIPTION
Add 'seccomp' as build depencency to address issue#3272